### PR TITLE
Notify for each new redeem ticket event since the last check

### DIFF
--- a/api/update.ts
+++ b/api/update.ts
@@ -92,6 +92,13 @@ export default async (req: VercelRequest, res: VercelResponse) => {
 
   const { timestamp } = await db.collection("payouts").findOne();
 
+  // Update last event time
+  if (winningTicketRedeemedEvents[0].timestamp > timestamp){
+    await db
+      .collection("payouts")
+      .replaceOne({}, { timestamp: winningTicketRedeemedEvents[0].timestamp });
+  }
+  
   // Build a queue of new winning tickets
   let ticketQueue = [];
   for (const thisTicket of winningTicketRedeemedEvents){
@@ -136,11 +143,6 @@ export default async (req: VercelRequest, res: VercelResponse) => {
       }),
       headers: { "Content-Type": "application/json" },
     });
-
-    // update last payout time
-    await db
-      .collection("payouts")
-      .replaceOne({}, { timestamp: newTicket.timestamp });
   }
 
   res.status(200).send("Success");

--- a/api/update.ts
+++ b/api/update.ts
@@ -93,18 +93,18 @@ export default async (req: VercelRequest, res: VercelResponse) => {
   const { timestamp } = await db.collection("payouts").findOne();
 
   // Update last event time
-  if (winningTicketRedeemedEvents[0].timestamp > timestamp){
+  if (winningTicketRedeemedEvents[0].timestamp > timestamp) {
     await db
       .collection("payouts")
       .replaceOne({}, { timestamp: winningTicketRedeemedEvents[0].timestamp });
   }
-  
+
   // Build a queue of new winning tickets
   let ticketQueue = [];
-  for (const thisTicket of winningTicketRedeemedEvents){
-    if (thisTicket.timestamp > timestamp){
+  for (const thisTicket of winningTicketRedeemedEvents) {
+    if (thisTicket.timestamp > timestamp) {
       ticketQueue.push(thisTicket);
-    }else{
+    } else {
       break;
     }
   }
@@ -129,9 +129,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
             color: 60296,
             title: "Orchestrator Payout",
             description: discordDescription,
-            timestamp: new Date(
-              newTicket.timestamp * 1000
-            ).toISOString(),
+            timestamp: new Date(newTicket.timestamp * 1000).toISOString(),
             url: `https://arbiscan.io/tx/${newTicket.transaction.id}`,
             ...(image && {
               thumbnail: {


### PR DESCRIPTION
In order to fix dreaded issue #5 where only the last new redeem event was being sent out, rather than all new events since the last check.

Didn't run/test this code, so it might need some adjustments to make it typescript compatible