### PR TITLE
Fix: Pull the last 20 tickets from the subgraph

### DIFF
--- a/api/update.ts
+++ b/api/update.ts
@@ -68,7 +68,7 @@ export default async (req: VercelRequest, res: VercelResponse) => {
   const query = gql`
     {
       winningTicketRedeemedEvents(
-        first: 1
+        first: 20
         orderDirection: desc
         orderBy: timestamp
       ) {


### PR DESCRIPTION
In order to make #6 work (the fix for #5), we need to pull more `winningTicketRedeemedEvents`. Now set it to 20. I don't know if this is a sensible number, but hopefully this finally fixes the issue